### PR TITLE
Fix agp 8 plus compatability

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,8 +58,8 @@ android {
     targetCompatibility JavaVersion.VERSION_17
   }
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_17.majorVersion
+  kotlin {
+    jvmToolchain(17)
   }
 
   namespace "expo.modules.widgets"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,16 +53,13 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
-  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
-    compileOptions {
-      sourceCompatibility JavaVersion.VERSION_17
-      targetCompatibility JavaVersion.VERSION_17
-    }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
 
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_17.majorVersion
-    }
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_17.majorVersion
   }
 
   namespace "expo.modules.widgets"


### PR DESCRIPTION

Small fix to make plugin work with AGP8. Replaced deprecated kotlinOptions.

Resolves:
https://github.com/mike-stewart-dev/expo-widgets/issues/51